### PR TITLE
Fixed problem when a container has the name of an existing image

### DIFF
--- a/lib/my_docker_rake.rb
+++ b/lib/my_docker_rake.rb
@@ -1,2 +1,2 @@
-require 'my_docker_rake/version'
-require 'my_docker_rake/utilities'
+require_relative 'my_docker_rake/version'
+require_relative 'my_docker_rake/utilities'

--- a/lib/my_docker_rake/tasks.rb
+++ b/lib/my_docker_rake/tasks.rb
@@ -1,5 +1,5 @@
-require 'my_docker_rake/extensions'
-require 'my_docker_rake/utilities'
+require_relative 'extensions'
+require_relative 'utilities'
 require 'rake/tasklib'
 
 

--- a/lib/my_docker_rake/tasks.rb
+++ b/lib/my_docker_rake/tasks.rb
@@ -91,7 +91,7 @@ module MyDockerRake
               docker run \
                 #{ _no_daemon ? '' : '-d' } \
                 --name #{container[:name]} \
-                --hostname #{container[:hostname] || container[:name].gsub(/\./, '_')} \
+                --hostname #{container[:hostname] || container[:name].gsub('_', '.')} \
                 #{ links.map { |l| "--link #{l}" }.join(' ') } \
                 #{ ports.map { |p| "-p #{p}" }.join(' ') } \
                 #{ volumes_from.map { |v| "--volumes-from #{v}" }.join(' ') } \

--- a/lib/my_docker_rake/utilities.rb
+++ b/lib/my_docker_rake/utilities.rb
@@ -11,8 +11,16 @@ module MyDockerRake
       `docker inspect -format "{{ .State.Running }}" #{container} 2>/dev/null`.chomp == 'true'
     end
 
+    def container_ids
+      container_ids =(`docker ps -a -q | xargs`).chomp
+    end
+    
     def container_names
-       names_output = `docker inspect --format "{{.Name}}" $(docker ps -a -q)`
+       ids = container_ids
+       if ids.blank?
+         return []
+       end
+       names_output = `docker inspect --format "{{.Name}}" #{ids}`
        unless names_output
          return []
        end

--- a/lib/my_docker_rake/utilities.rb
+++ b/lib/my_docker_rake/utilities.rb
@@ -11,8 +11,19 @@ module MyDockerRake
       `docker inspect -format "{{ .State.Running }}" #{container} 2>/dev/null`.chomp == 'true'
     end
 
+    def container_names
+       names_output = `docker inspect --format "{{.Name}}" $(docker ps -a -q)`
+       unless names_output
+         return []
+       end
+       names_output.lines.map{|n| n.match(/\/(.+)/)[1] }
+    rescue =>e
+      puts "Encountered a problem trying to parse container names"
+      raise e
+    end
+    
     def has_container?(container)
-      system("docker inspect #{container} >/dev/null 2>&1")
+      container_names.any?{|n| n == container}      
     end
 
     def kill_container(container, *args)


### PR DESCRIPTION
Hi,

I needed some rake tasks exactly like the ones you made.
There is no need to use a gemfile in my case as i don't want to bundle anything and needlessly comlicate things so i just get the code and require it.
This is why i changed in to require relative instead of require.
As far as i can tell it has no adverse effects.
Another problem i encountered is when a container had the name of an image.
"docker inspect" would return the details of that image and will cause the 'has_container?' method to return wrong true even though there is no container.
I hope you'll find these changes useful too.

Thanks for sharing your work!
Gal.
